### PR TITLE
fix: LTS names must be lowercase

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/Jod
+lts/jod


### PR DESCRIPTION
previewのデプロイをしようと思うとビルドエラーがでるので、指摘どおりにしてみます。

https://app.netlify.com/projects/gocon2025/deploys/68282d8f6e7c9cac247458e1
```
3:32:52 PM: Failed during stage 'Install dependencies': dependency_installation script returned non-zero exit code: 1
3:32:52 PM: Attempting Node.js version 'lts/Jod' from .nvmrc
3:32:52 PM: LTS names must be lowercase
3:32:52 PM: Version with LTS filter 'Jod' not found - try `nvm ls-remote --lts=Jod` to browse available versions.
3:32:52 PM: Failed to install Node.js version 'lts/Jod'
3:32:52 PM: Failing build: Failed to install dependencies
```