### PR TITLE
fix: Sは大文字

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,7 +51,7 @@ import Layout from "../layouts/Layout.astro";
               </ul>
             </li>
             <li>
-              <span style="font-weight: bold">セッション Cfs募集：</span>
+              <span style="font-weight: bold">セッション CfS募集：</span>
               <ul>
                 <li>
                   <a


### PR DESCRIPTION
# WHY
https://goconjp.slack.com/archives/C081CJUH59A/p1747190285450919
> CfS (Call for Speakers) でSは大文字なので、次回更新時にでも混ぜてもらえると
