### PR TITLE
💄 スマホのナビゲーションのバックグラウンド調整

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -88,7 +88,8 @@ import Button from "./Button.astro";
         align-items: flex-start;
         padding: 40px 32px 73px;
         gap: 40px;
-        background: var(--surface-primary);
+        background: rgba(255, 255, 255, 0.8);
+        backdrop-filter: blur(32px);
         z-index: 1000;
 
         & ul {


### PR DESCRIPTION
## やったこと

デザインでGoGo出たスマホ時のナビゲーションを白一色から透過＋ぼかしにしました