### PR TITLE
ci: previewサイトをビルドするときの設定を別に定義

### DIFF
--- a/astro.netlify.config.mjs
+++ b/astro.netlify.config.mjs
@@ -1,0 +1,12 @@
+// @ts-check
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  i18n: {
+    defaultLocale: "ja",
+    locales: ["ja"],
+    routing: {
+      prefixDefaultLocale: false,
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro check && astro build",
+    "preview-build": "astro check && astro build --config astro.netlify.config.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "format": "prettier --write '**/*.{astro,js,mjs,json,json5,ts,yaml,yml}'",


### PR DESCRIPTION
# WHY
github pagesデプロイ時とnetlifyのpreviewサイトのデプロイではbase urlが違います。

# ref
https://docs.astro.build/ja/guides/configuring-astro/#%E8%A8%AD%E5%AE%9A%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%AE%E6%8C%87%E5%AE%9A