### PR TITLE
💄 フォントを指定した

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
+    "@fontsource-variable/noto-sans": "^5.2.7",
+    "@fontsource-variable/noto-sans-jp": "^5.2.5",
+    "@fontsource/barlow": "^5.2.5",
     "astro": "^5.7.13",
     "typescript": "^5.8.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.4
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.5.3)(typescript@5.8.3)
+      '@fontsource-variable/noto-sans':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource-variable/noto-sans-jp':
+        specifier: ^5.2.5
+        version: 5.2.5
+      '@fontsource/barlow':
+        specifier: ^5.2.5
+        version: 5.2.5
       astro:
         specifier: ^5.7.13
         version: 5.7.13(@types/node@22.15.20)(rollup@4.41.0)(typescript@5.8.3)(yaml@2.8.0)
@@ -273,6 +282,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/noto-sans-jp@5.2.5':
+    resolution: {integrity: sha512-+ieDlugS+FCva2eLahVgybiaPMs1xLcBYByflzw1WghvFPFNJzsQHw85N+dadXzaqccVTiVDGYW4E0bMv4CHAQ==}
+
+  '@fontsource-variable/noto-sans@5.2.7':
+    resolution: {integrity: sha512-VaA+clV7xTOx+pSOdyjr9nR7khjrJGr7ZHs2KXlx+AqLyG/SUVBadNwauCH0rvF/eZkZr67neNxdKMOLtVxweg==}
+
+  '@fontsource/barlow@5.2.5':
+    resolution: {integrity: sha512-p+2XXEM7v85kbn0Dh8g0YLMjTCDiRCAi9nHik6w/2owZ9CkT1yYGGgaUMshJRqykh7efv1gE0QxAkOhZHd8tEg==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -2283,6 +2301,12 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.4':
     optional: true
+
+  '@fontsource-variable/noto-sans-jp@5.2.5': {}
+
+  '@fontsource-variable/noto-sans@5.2.7': {}
+
+  '@fontsource/barlow@5.2.5': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -131,8 +131,6 @@ import { concatWithBase } from "../utils/concatWithBase";
   }
 
   .column-title {
-    font-family: "Noto Sans JP", sans-serif;
-    font-style: normal;
     font-weight: 700;
     font-size: 16px;
     line-height: 175%;
@@ -147,8 +145,6 @@ import { concatWithBase } from "../utils/concatWithBase";
   }
 
   .text-link {
-    font-family: "Noto Sans JP", sans-serif;
-    font-style: normal;
     font-weight: 700;
     font-size: 14px;
     line-height: 175%;
@@ -195,8 +191,6 @@ import { concatWithBase } from "../utils/concatWithBase";
     flex-direction: row;
     align-items: center;
     gap: 24px;
-    font-family: "Noto Sans JP", sans-serif;
-    font-style: normal;
     font-weight: 700;
     font-size: 14px;
     line-height: 175%;
@@ -209,8 +203,6 @@ import { concatWithBase } from "../utils/concatWithBase";
   }
 
   .copyright {
-    font-family: "Noto Sans JP", sans-serif;
-    font-style: normal;
     font-weight: 400;
     font-size: 16px;
     line-height: 175%;

--- a/src/components/GlobalStyles.astro
+++ b/src/components/GlobalStyles.astro
@@ -1,4 +1,7 @@
 ---
+import "@fontsource-variable/noto-sans";
+import "@fontsource-variable/noto-sans-jp";
+
 /** サイト全体のデザイントークンやグローバルスタイルを定義する */
 ---
 
@@ -28,6 +31,7 @@
   body {
     margin: 0;
     padding: 0;
+    font-family: "Noto Sans", "Noto Sans JP", sans-serif;
   }
 
   .section-title {

--- a/src/components/MainVisual.astro
+++ b/src/components/MainVisual.astro
@@ -1,4 +1,5 @@
 ---
+import "@fontsource/barlow/700.css";
 import { Image } from "astro:assets";
 import Gopher from "../assets/mv-gophers.png";
 import Logo from "../assets/mv-logo.svg";
@@ -96,6 +97,7 @@ import Button from "./Button.astro";
     border-radius: 24px;
     margin: -105px auto 0;
     padding: 16px 120px;
+    font-family: "Barlow", sans-serif;
     z-index: 2;
 
     @media screen and (max-width: 860px) {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import "@fontsource/barlow/700.css";
 import { Image } from "astro:assets";
 import Gopher from "../assets/page-header-gopher.png";
 import Footer from "../components/Footer.astro";
@@ -98,6 +99,7 @@ const pageTitle =
     }
 
     & .en {
+      font-family: "Barlow", sans-serif;
       font-size: 68px;
       line-height: 1.5;
 


### PR DESCRIPTION
## やったこと

ビルドする静的なサイトのため、Google FontをCDNから取得するのではなく、fontsourceで必要なフォントとweightをセルフホストする方向にしてみました

## 使用フォント

- 日本語：Noto Sans JP
- 英語：Noto Sans
- メインビジュアルの日付部分：Barlow
- ページタイトル（英語部分）：Barlow