### PR TITLE
🌐 各ページの日付表記を多言語対応

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,7 +6,11 @@ export const constants = {
   pageDescription:
     "Go Conference is a conference for Go programming language users.",
   sponsorship: {
-    start: "2024/01/01 00:00:00",
-    end: "2024/03/31 23:59:59",
+    start: new Date(Date.UTC(2023, 11, 31, 15, 0, 0)), // 2024/01/01 00:00:00 JST
+    end: new Date(Date.UTC(2024, 2, 31, 14, 59, 59)), // 2024/03/31 23:59:59 JST
+  },
+  proposal: {
+    start: new Date(Date.UTC(2025, 4, 13, 3, 0, 0)), // 2025/05/13 12:00:00 JST
+    end: new Date(Date.UTC(2025, 5, 18, 14, 59, 59)), // 2025/06/18 23:59:59 JST
   },
 };

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -30,9 +30,16 @@ const currentLocale = Astro.currentLocale || "ja";
         <tr>
           <th><Chip class="chip" variant="secondary">Date & Time</Chip></th>
           <td>
-            Day 1: September 27, 2025 (Sat) 10:00 - 19:00 (Doors open 9:00)<br
-            />
-            Day 2: September 28, 2025 (Sun) 10:00 - 19:00 (Doors open 9:00)
+            <p>
+              Day 1<br />
+              Saturday, September 27, 2025<br />
+              10:00 AM - 7:00 PM JST (Doors open 9:00 AM JST)
+            </p>
+            <p>
+              Day 2<br />
+              Sunday, September 28, 2025<br />
+              10:00 AM - 7:00 PM JST (Doors open 9:00 AM JST)
+            </p>
           </td>
         </tr>
         <tr>

--- a/src/pages/en/proposal.astro
+++ b/src/pages/en/proposal.astro
@@ -1,8 +1,12 @@
 ---
 import Button from "../../components/Button.astro";
 import Chip from "../../components/Chip.astro";
+import { constants } from "../../constants";
 import Layout from "../../layouts/Layout.astro";
 import "../../styles/proposal.css";
+import { formatDate } from "../../utils/dateFormat";
+
+const currentLocale = Astro.currentLocale || "ja";
 ---
 
 <Layout title="プロポーザル" titleEn="Proposal">
@@ -16,7 +20,11 @@ import "../../styles/proposal.css";
         <h3 class="period-title">
           <Chip variant="secondary">Submission Period</Chip>
         </h3>
-        <div class="period-date">2025/05/13 12:00:00 ~ 2025/06/18 23:59:59</div>
+        <div class="period-date">
+          {formatDate(constants.proposal.start, currentLocale)} ~ {
+            formatDate(constants.proposal.end, currentLocale)
+          }
+        </div>
       </div>
       <div class="button-wrapper">
         <Button

--- a/src/pages/en/sponsorship.astro
+++ b/src/pages/en/sponsorship.astro
@@ -4,6 +4,9 @@ import Chip from "../../components/Chip.astro";
 import { constants } from "../../constants";
 import Layout from "../../layouts/Layout.astro";
 import "../../styles/sponsorship.css";
+import { formatDate } from "../../utils/dateFormat";
+
+const currentLocale = Astro.currentLocale || "ja";
 ---
 
 <Layout title="スポンサー" titleEn="Sponsorship">
@@ -16,9 +19,9 @@ import "../../styles/sponsorship.css";
       </h3>
       <div class="sponsorship-date">
         <p class="inner">
-          <span>{constants.sponsorship.start}</span>
+          <span>{formatDate(constants.sponsorship.start, currentLocale)}</span>
           <span>~</span>
-          <span>{constants.sponsorship.end}</span>
+          <span>{formatDate(constants.sponsorship.end, currentLocale)}</span>
         </p>
       </div>
     </div>

--- a/src/pages/proposal.astro
+++ b/src/pages/proposal.astro
@@ -1,8 +1,10 @@
 ---
 import Button from "../components/Button.astro";
 import Chip from "../components/Chip.astro";
+import { constants } from "../constants";
 import Layout from "../layouts/Layout.astro";
 import "../styles/proposal.css";
+import { formatDate } from "../utils/dateFormat";
 ---
 
 <Layout title="プロポーザル" titleEn="Proposal">
@@ -16,7 +18,11 @@ import "../styles/proposal.css";
         <h3 class="period-title">
           <Chip variant="secondary">募集期間</Chip>
         </h3>
-        <div class="period-date">2025/05/13 12:00:00 ~ 2025/06/18 23:59:59</div>
+        <div class="period-date">
+          {formatDate(constants.proposal.start)} ~ {
+            formatDate(constants.proposal.end)
+          }
+        </div>
       </div>
       <div class="button-wrapper">
         <Button

--- a/src/pages/sponsorship.astro
+++ b/src/pages/sponsorship.astro
@@ -4,6 +4,7 @@ import Chip from "../components/Chip.astro";
 import { constants } from "../constants";
 import Layout from "../layouts/Layout.astro";
 import "../styles/sponsorship.css";
+import { formatDate } from "../utils/dateFormat";
 ---
 
 <Layout title="スポンサー" titleEn="Sponsorship">
@@ -16,9 +17,9 @@ import "../styles/sponsorship.css";
       </h3>
       <div class="sponsorship-date">
         <p class="inner">
-          <span>{constants.sponsorship.start}</span>
+          <span>{formatDate(constants.sponsorship.start)}</span>
           <span>~</span>
-          <span>{constants.sponsorship.end}</span>
+          <span>{formatDate(constants.sponsorship.end)}</span>
         </p>
       </div>
     </div>

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -5,14 +5,17 @@
  * @returns フォーマットされた日付文字列
  */
 export function formatDate(date: Date, locale: string = "ja") {
-  return new Intl.DateTimeFormat(locale, {
+  // 日本語以外ではタイムゾーンの表記を追加（timeZoneName: 'short' の挙動が不安定なため温かみのある運用）
+  const appendTimeZone = locale === "ja" ? "" : " JST";
+  const formattedDate = new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
-    timeZone: "Asia/Tokyo", // 日本時間に設定
-    timeZoneName: locale !== "ja" ? "shortGeneric" : undefined, // 日本語以外ではタイムゾーン名を表示
+    timeZone: "Asia/Tokyo", // 日本時間に固定
   }).format(date);
+
+  return `${formattedDate}${appendTimeZone}`;
 }

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,0 +1,18 @@
+/**
+ * 日付を指定されたロケールでフォーマットする関数
+ * @param date 日付オブジェクト(UTC)
+ * @param locale ロケール文字列（デフォルトは 'ja'）
+ * @returns フォーマットされた日付文字列
+ */
+export function formatDate(date: Date, locale: string = "ja") {
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZone: "Asia/Tokyo", // 日本時間に設定
+    timeZoneName: locale !== "ja" ? "shortGeneric" : undefined, // 日本語以外ではタイムゾーン名を表示
+  }).format(date);
+}


### PR DESCRIPTION
## やったこと

- 各種期間をUTCで定数管理
- localeによっていい感じにフォーマットしてくれる関数を追加
- 各ページの日付表記を修正