### PR TITLE
フッターのリンクをヘッダーに合わせる

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,6 +17,14 @@ const currentLocale = Astro.currentLocale || "ja";
               >Home</a
             >
             <a
+              href={getRelativeLocaleUrl(currentLocale, "sponsorship")}
+              class="text-link">Sponsorship</a
+            >
+            <a
+              href={getRelativeLocaleUrl(currentLocale, "workshop")}
+              class="text-link">Workshop</a
+            >
+            <a
               href={getRelativeLocaleUrl(currentLocale, "proposal")}
               class="text-link">Proposal</a
             >


### PR DESCRIPTION
- フッターのリンクがヘッダーとあっていなかったため修正しました