### PR TITLE
プロポーザル募集終了に伴うサイト更新

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,8 +17,12 @@ const currentLocale = Astro.currentLocale || "ja";
               >Home</a
             >
             <a
-              href={getRelativeLocaleUrl(currentLocale, "proposal")}
-              class="text-link">Proposal</a
+              href={getRelativeLocaleUrl(currentLocale, "sponsorship")}
+              class="text-link">Sponsorship</a
+            >
+            <a
+              href={getRelativeLocaleUrl(currentLocale, "workshop")}
+              class="text-link">Workshop</a
             >
           </div>
         </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -210,12 +210,9 @@ const currentLocale = Astro.currentLocale || "ja";
           Sponsorship
         </a>
       </li>
-      <li>
-        <a href={getRelativeLocaleUrl(currentLocale, "workshop")}>Workshop</a>
-      </li>
     </ul>
-    <Button href={getRelativeLocaleUrl(currentLocale, "proposal")}>
-      {currentLocale === "ja" ? "プロポーザルに応募" : "Call for Proposals"}
+    <Button href={getRelativeLocaleUrl(currentLocale, "workshop")}>
+      {currentLocale === "ja" ? "ワークショップに応募" : "Apply for Workshop"}
     </Button>
     <ul class="language-switcher">
       <li class="language-link">

--- a/src/components/MainVisual.astro
+++ b/src/components/MainVisual.astro
@@ -200,10 +200,14 @@ const currentLocale = Astro.currentLocale || "ja";
     <div class="cta-button">
       <div class="cta-button-inner">
         <Button
-          href={getRelativeLocaleUrl(currentLocale, "proposal")}
+          href={getRelativeLocaleUrl(currentLocale, "workshop")}
           size="large"
         >
-          {currentLocale === "ja" ? "プロポーザルに応募" : "Call for Proposals"}
+          {
+            currentLocale === "ja"
+              ? "ワークショップに応募"
+              : "Apply for Workshop"
+          }
         </Button>
       </div>
     </div>

--- a/src/pages/en/proposal.astro
+++ b/src/pages/en/proposal.astro
@@ -12,25 +12,7 @@ const currentLocale = Astro.currentLocale || "ja";
 <Layout title="プロポーザル" titleEn="Proposal">
   <h2 class="section-title">Call for Proposals</h2>
   <div class="contents">
-    <p>Go Conference is calling for proposals.</p>
-    <div class="summary">
-      <h3 class="sponsorship-title">
-        <Chip variant="secondary">Submission Period</Chip>
-      </h3>
-      <div class="sponsorship-date">
-        <p class="inner">
-          <span>{formatDate(constants.proposal.start, currentLocale)}</span>
-          <span>~</span>
-          <span>{formatDate(constants.proposal.end, currentLocale)}</span>
-        </p>
-      </div>
-    </div>
-    <p>
-      <Button
-        href="https://sessionize.com/go-conference-2025/"
-        size="large"
-        target="_blank">Apply Here</Button
-      >
-    </p>
+    <p>The call for proposals has ended.</p>
+    <p>Thank you for all the submissions we received.</p>
   </div>
 </Layout>

--- a/src/pages/proposal.astro
+++ b/src/pages/proposal.astro
@@ -10,25 +10,7 @@ import { formatDate } from "../utils/dateFormat";
 <Layout title="プロポーザル" titleEn="Proposal">
   <h2 class="section-title">プロポーザルの募集について</h2>
   <div class="contents">
-    <p>Go Conferenceではプロポーザルを募集します。</p>
-    <div class="summary">
-      <h3 class="sponsorship-title">
-        <Chip variant="secondary">募集期間</Chip>
-      </h3>
-      <div class="sponsorship-date">
-        <p class="inner">
-          <span>{formatDate(constants.proposal.start)}</span>
-          <span>~</span>
-          <span>{formatDate(constants.proposal.end)}</span>
-        </p>
-      </div>
-    </div>
-    <p>
-      <Button
-        href="https://sessionize.com/go-conference-2025/"
-        size="large"
-        target="_blank">申し込みはこちら</Button
-      >
-    </p>
+    <p>プロポーザルの募集は終了いたしました。</p>
+    <p>たくさんのご応募をいただき、ありがとうございました。</p>
   </div>
 </Layout>


### PR DESCRIPTION
- ヘッダー
  - 右上の「プロポーザルに応募」ボタンを「ワークショップに応募」に差し替え
- ホーム
  - メインビジュアルのリンクを「プロポーザルに応募」から「ワークショップに応募」に差し替え
- プロポーザル募集
  - `/2025/proposal/` 自体は残すが、募集ボタンを削除し募集終了の文言を表示
- フッター
  - ヘッダーと合わせて不足分のリンク追加