### PR TITLE
スポンサーページに プラチナ Go ルド / Go ルド / シルバー の募集を終了した旨を追加しました

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -18,6 +18,10 @@ const currentLocale = Astro.currentLocale || "ja";
               >Home</a
             >
             <a
+              href={getRelativeLocaleUrl(currentLocale, "sponsorship")}
+              class="text-link">Sponsorship</a
+            >
+            <a
               href="https://docs.google.com/document/d/1LxjzxHK23aTAFvGZeR-BpHf8sC6RKAqbImtnUtxQ3Yo/edit?tab=t.0#heading=h.n5j5dks9hlev"
               class="text-link external-link"
               target="_blank"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -241,6 +241,11 @@ const currentLocale = Astro.currentLocale || "ja";
   <div class="navigation">
     <ul class="navigation-menu">
       <li><a href={getRelativeLocaleUrl(currentLocale)}>Home</a></li>
+      <li>
+        <a href={getRelativeLocaleUrl(currentLocale, "sponsorship")}>
+          Sponsorship
+        </a>
+      </li>
     </ul>
     <a
       href="https://docs.google.com/document/d/1LxjzxHK23aTAFvGZeR-BpHf8sC6RKAqbImtnUtxQ3Yo/edit?tab=t.0#heading=h.n5j5dks9hlev"

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,7 +7,7 @@ export const constants = {
     "Go Conference is a conference for Go programming language users.",
   sponsorship: {
     start: new Date(Date.UTC(2025, 4, 31, 15, 0, 0)), // 2025/06/01 00:00:00 JST
-    end: new Date(Date.UTC(2025, 5, 30, 14, 59, 59)), // 2024/06/30 23:59:59 JST
+    end: new Date(Date.UTC(2025, 7, 31, 14, 59, 59)), // 2025/08/31 23:59:59 JST
   },
   proposal: {
     start: new Date(Date.UTC(2025, 4, 13, 3, 0, 0)), // 2025/05/13 12:00:00 JST

--- a/src/pages/en/sponsorship.astro
+++ b/src/pages/en/sponsorship.astro
@@ -1,6 +1,10 @@
 ---
+import Button from "../../components/Button.astro";
+import Chip from "../../components/Chip.astro";
+import { constants } from "../../constants";
 import Layout from "../../layouts/Layout.astro";
 import "../../styles/sub-page.css";
+import { formatDate } from "../../utils/dateFormat";
 
 const currentLocale = Astro.currentLocale || "ja";
 ---
@@ -8,7 +12,29 @@ const currentLocale = Astro.currentLocale || "ja";
 <Layout title="スポンサー" titleEn="Sponsorship">
   <h2 class="section-title">Call for Sponsors</h2>
   <div class="contents">
-    <p>The call for sponsors has ended.</p>
-    <p>Thank you for all the submissions we received.</p>
+    <p>Go Conference is looking for sponsors.</p>
+    <strong>
+      The call for Platinum, Gold, and Silver sponsors for Go Conference 2025
+      has ended.
+    </strong>
+    <div class="summary">
+      <h3 class="sponsorship-title">
+        <Chip variant="secondary">Application Period</Chip>
+      </h3>
+      <div class="sponsorship-date">
+        <p class="inner">
+          <span>{formatDate(constants.sponsorship.start, currentLocale)}</span>
+          <span>~</span>
+          <span>{formatDate(constants.sponsorship.end, currentLocale)}</span>
+        </p>
+      </div>
+    </div>
+    <p>
+      <Button
+        href="https://forms.gle/M2XAgH53HKiHJTGE9"
+        target="_blank"
+        size="large">Apply Here</Button
+      >
+    </p>
   </div>
 </Layout>

--- a/src/pages/sponsorship.astro
+++ b/src/pages/sponsorship.astro
@@ -10,7 +10,29 @@ import { formatDate } from "../utils/dateFormat";
 <Layout title="スポンサー" titleEn="Sponsorship">
   <h2 class="section-title">スポンサーの募集について</h2>
   <div class="contents">
-    <p>スポンサーの募集は終了いたしました。</p>
-    <p>たくさんのご応募をいただき、ありがとうございました。</p>
+    <p>Go Conferenceではスポンサーを募集します。</p>
+    <strong>
+      Go Conference 2025 の プラチナGoルド / Goルド / シルバー
+      スポンサーの募集は終了しました。
+    </strong>
+    <div class="summary">
+      <h3 class="sponsorship-title">
+        <Chip variant="secondary">募集期間</Chip>
+      </h3>
+      <div class="sponsorship-date">
+        <p class="inner">
+          <span>{formatDate(constants.sponsorship.start)}</span>
+          <span>~</span>
+          <span>{formatDate(constants.sponsorship.end)}</span>
+        </p>
+      </div>
+    </div>
+    <p>
+      <Button
+        href="https://forms.gle/M2XAgH53HKiHJTGE9"
+        target="_blank"
+        size="large">申し込みはこちら</Button
+      >
+    </p>
   </div>
 </Layout>


### PR DESCRIPTION
## やったこと

- スポンサーページが隠されていたので、表示されるようにしました
- スポンサーページに プラチナ Go ルド / Go ルド / シルバー の募集を終了した旨を追加しました
- スポンサー募集締め切り時刻を修正しました