### PR TITLE
メインビジュアルのボタンテキストを変更

### DIFF
--- a/src/components/MainVisual.astro
+++ b/src/components/MainVisual.astro
@@ -200,13 +200,13 @@ const currentLocale = Astro.currentLocale || "ja";
     <div class="cta-button">
       <div class="cta-button-inner">
         <Button
-          href={getRelativeLocaleUrl(currentLocale, "workshop")}
+          href={getRelativeLocaleUrl(currentLocale, "sponsorship")}
           size="large"
         >
           {
             currentLocale === "ja"
-              ? "ワークショップに応募"
-              : "Apply for Workshop"
+              ? "スポンサーに申し込む"
+              : "Apply for Sponsorship"
           }
         </Button>
       </div>


### PR DESCRIPTION
- トップのボタンに「ワークショップに応募」が残っていたので、スポンサー募集ページに差し替えました