### PR TITLE
Platinum Gold の表記微修正

### DIFF
--- a/src/components/SponsorBoard.astro
+++ b/src/components/SponsorBoard.astro
@@ -113,7 +113,7 @@ const currentLocale = Astro.currentLocale || "ja";
 </style>
 
 <div class="sponsor-section">
-  <!-- 
+  <!--
   CA さんの情報が揃い次第コメントアウトを外す
   <div>
     <h2>{currentLocale === "ja" ? "会場スポンサー" : "Venue Sponsor"}</h2>
@@ -170,7 +170,7 @@ const currentLocale = Astro.currentLocale || "ja";
   </div>
 
   <div>
-    <h2>Platinum "<span class="accent">Go</span> "ld</h2>
+    <h2>Platinum "<span class="accent">Go</span>"ld</h2>
     <ul class="platinum-gold-sponsor-list">
       {
         constants.jobBoard.platinumGoldSponsors.map((sponsor) => (
@@ -252,7 +252,7 @@ const currentLocale = Astro.currentLocale || "ja";
       }
     </ul>
   </div>
-  <!-- 
+  <!--
   08/31 の締め切り終了後に対応する
   <div>
     <h2>Bronze</h2>


### PR DESCRIPTION
Goの後ろに余分は半角スペースが入っていたので削除しました

before: `Platinum "Go "ld`
after: `Platinum "Go"ld`