### PR TITLE
fix: Minor typo fix in EN version

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -255,8 +255,11 @@ const currentLocale = Astro.currentLocale || "ja";
       <span>Sponsor FAQ</span>
       <OpenInNewIcon class="external-icon" />
     </a>
-    <Button href="https://ti.to/gophers-japan/go-conference-2025" target="_blank">
-      {currentLocale === "ja" ? "イベントに申し込む" : "Apply for the evnet"}
+    <Button
+      href="https://ti.to/gophers-japan/go-conference-2025"
+      target="_blank"
+    >
+      {currentLocale === "ja" ? "イベントに申し込む" : "Apply for the event"}
     </Button>
     <ul class="language-switcher">
       <li class="language-link">


### PR DESCRIPTION
Fixes spelling "evnet" to "event". No functional changes.