### PR TITLE
fix: Incorrect use of plural "Staffs"

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -27,7 +27,7 @@ const currentLocale = Astro.currentLocale || "ja";
             >
             <a
               href={getRelativeLocaleUrl(currentLocale, "staffs")}
-              class="text-link">Staffs</a
+              class="text-link">Staff</a
             >
             <a
               href="https://docs.google.com/document/d/1LxjzxHK23aTAFvGZeR-BpHf8sC6RKAqbImtnUtxQ3Yo/edit?tab=t.0#heading=h.n5j5dks9hlev"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -243,7 +243,7 @@ const currentLocale = Astro.currentLocale || "ja";
         </a>
       </li>
       <li>
-        <a href={getRelativeLocaleUrl(currentLocale, "staffs")}> Staffs </a>
+        <a href={getRelativeLocaleUrl(currentLocale, "staffs")}> Staff </a>
       </li>
     </ul>
     <a
@@ -255,7 +255,10 @@ const currentLocale = Astro.currentLocale || "ja";
       <span>Sponsor FAQ</span>
       <OpenInNewIcon class="external-icon" />
     </a>
-    <Button href="https://ti.to/gophers-japan/go-conference-2025" target="_blank">
+    <Button
+      href="https://ti.to/gophers-japan/go-conference-2025"
+      target="_blank"
+    >
       {currentLocale === "ja" ? "イベントに申し込む" : "Apply for the evnet"}
     </Button>
     <ul class="language-switcher">

--- a/src/pages/en/staffs.astro
+++ b/src/pages/en/staffs.astro
@@ -4,6 +4,6 @@ import Layout from "../../layouts/Layout.astro";
 import "../../styles/sub-page.css";
 ---
 
-<Layout title="スタッフ" titleEn="Staffs">
+<Layout title="スタッフ" titleEn="Staff">
   <StaffList />
 </Layout>

--- a/src/pages/staffs.astro
+++ b/src/pages/staffs.astro
@@ -4,6 +4,6 @@ import Layout from "../layouts/Layout.astro";
 import "../styles/sub-page.css";
 ---
 
-<Layout title="スタッフ" titleEn="Staffs">
+<Layout title="スタッフ" titleEn="Staff">
   <StaffList />
 </Layout>


### PR DESCRIPTION
Plural of word "staff" (as in set of employees, volunteers, etc.) for one owning entity is also "staff". "Staffs" would be only used if there are more owning entities and each has their own "staff".

E.g.: Company has exceptional staff. vs Companies distributed stocks to their staffs.

See: https://english.stackexchange.com/a/34721