### PR TITLE
ジョブボードのレイアウト変更

### DIFF
--- a/src/components/JobBoardCard.astro
+++ b/src/components/JobBoardCard.astro
@@ -19,54 +19,42 @@ const { src, alt, width, height, link } = Astro.props;
     flex-direction: column;
     gap: 80px;
     border: 2px solid var(--primitive-light-gray);
-    border-radius: 16px;
-    padding: 24px;
     flex: 0 0 calc(100% / 3);
-    max-height: 416px;
-    max-width: 1200px;
-  }
-
-  .board-card-inner {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: stretch;
-    width: 100%;
-    flex: 1;
+    width: 540px;
+    height: 270px;
   }
 
   .board-card img {
-    max-width: 100%;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
     display: block;
-    margin: 0 auto;
+    image-rendering: -webkit-optimize-contrast;
+    image-rendering: auto;
   }
 
-  .board-card p {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    max-height: 120px;
-    overflow: hidden;
-    -webkit-line-clamp: 4;
-    text-overflow: ellipsis;
+  .board-card a {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+  }
+
+  @media (max-width: 1200px) {
+    .board-card {
+      grid-template-columns: 1fr; /* 1200px以下なら1列 */
+      width: unset;
+      height: unset;
+      max-width: 1120px;
+      max-height: 560px;
+      aspect-ratio: 2 / 1;
+    }
   }
 </style>
 
 <div class="board-card">
-  <div class="board-card-inner">
-    <div style="flex: 1">
-      <Image src={src} alt={alt} width={width} height={height} loading="lazy" />
-    </div>
-
-    {
-      link && (
-        <div style="width: 100%;">
-          <Button variant="secondary" fullWidth href={link} target="_blank">
-            {currentLocale === "ja" ? "詳細を見る" : "View Details"}
-          </Button>
-        </div>
-      )
-    }
-  </div>
+  <a href={link} target="_blank">
+    <Image src={src} alt={alt} width={width} height={height} loading="lazy" />
+  </a>
 </div>

--- a/src/pages/en/jobboard.astro
+++ b/src/pages/en/jobboard.astro
@@ -8,20 +8,16 @@ import NoImage from "../../assets/sponsors/no-image.png";
 <style>
   .job-board {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: 1fr 1fr;
     padding: 20px;
     width: 100%;
     gap: 24px;
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 1200px) {
     .job-board {
-      grid-template-columns: 1fr 1fr; /* 画面が900px以下なら2列 */
-    }
-  }
-  @media (max-width: 600px) {
-    .job-board {
-      grid-template-columns: 1fr; /* 600px以下なら1列 */
+      padding: unset;
+      grid-template-columns: 1fr; /* 1200px以下なら1列 */
     }
   }
 </style>

--- a/src/pages/jobboard.astro
+++ b/src/pages/jobboard.astro
@@ -8,20 +8,16 @@ import NoImage from "../assets/sponsors/no-image.png";
 <style>
   .job-board {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: 1fr 1fr;
     padding: 20px;
     width: 100%;
     gap: 24px;
   }
 
-  @media (max-width: 900px) {
+  @media (max-width: 1200px) {
     .job-board {
-      grid-template-columns: 1fr 1fr; /* 画面が900px以下なら2列 */
-    }
-  }
-  @media (max-width: 600px) {
-    .job-board {
-      grid-template-columns: 1fr; /* 600px以下なら1列 */
+      padding: unset;
+      grid-template-columns: 1fr; /* 1200px以下なら1列 */
     }
   }
 </style>


### PR DESCRIPTION
- ジョブボードのレイアウトを3列 -> 2列に変更しました
- 詳細を見るボタンが不要になるため全体的に画像幅を広げるためにレイアウト調整