### PR TITLE
fix: Translate service session titles

### DIFF
--- a/src/components/Timetable/TimetableList.astro
+++ b/src/components/Timetable/TimetableList.astro
@@ -6,8 +6,11 @@ import {
   getFormattedTime,
   getTimeSlotSpanCount,
   isTimeSlotOccupied,
+  getTranslated,
 } from "../../utils/timetable";
 import WorkshopCard from "./WorkshopCard.astro";
+
+const currentLocale = Astro.currentLocale || "ja";
 
 interface Props {
   /**
@@ -119,7 +122,7 @@ if (classifiedSessions.length === 0) {
                 {room1?.isServiceSession ? (
                   <CommonTimetableCard
                     id={room1.id}
-                    title={room1.title}
+                    title={getTranslated(room1.title, currentLocale)}
                     startAt={getFormattedTime(room1.startsAt)}
                     endAt={getFormattedTime(room1.endsAt)}
                   />
@@ -147,7 +150,7 @@ if (classifiedSessions.length === 0) {
                     // 休憩の場合
                     <CommonTimetableCard
                       id={room2.id}
-                      title={room2.title}
+                      title={getTranslated(room2.title, currentLocale)}
                       startAt={getFormattedTime(room2.startsAt)}
                       endAt={getFormattedTime(room2.endsAt)}
                     />
@@ -177,7 +180,7 @@ if (classifiedSessions.length === 0) {
                     // 休憩の場合
                     <CommonTimetableCard
                       id={room3.id}
-                      title={room3.title}
+                      title={getTranslated(room3.title, currentLocale)}
                       startAt={getFormattedTime(room3.startsAt)}
                       endAt={getFormattedTime(room3.endsAt)}
                     />

--- a/src/utils/timetable.ts
+++ b/src/utils/timetable.ts
@@ -208,3 +208,23 @@ export const isSponsoredSession = (
   // answerが"true"の場合はスポンサーセッションと判定
   return sponsoredSession?.answer === "true" || false;
 };
+
+/**
+ * Try to translate session related string to locale. Fallback to given string
+ * if translation does not exist.
+ * @param str a string to translate
+ * @param locale a locale to translate to
+ * @returns translated string or str if translation not found
+ */
+export const getTranslated = (str: string, locale: string) => {
+  // TODO: leaving translation table here because it is small, but can be moved
+  // to json if needed
+  const transl: { [key: string]: { [key: string]: string } } = {
+    en: {
+      休憩: "Break",
+      お昼休憩: "Lunch Break",
+      場面転換: "Stage Setup",
+    },
+  };
+  return locale in transl && str in transl[locale] ? transl[locale][str] : str;
+};


### PR DESCRIPTION
Adds `getTranslated(str, locale)` to `utils/timetable.ts` that takes `str` and tries to translate to `locale` using built in map. If no translation is found it just returns `str`.

`getTranslated` is applied to all service session titles only as agreedon Slack. Unfortunately we cannot add anything to JSON as it gets downloaded from Sessionize API so this is the best we can do.

Service sessions are not clickable so only place where translations are needed is really TimetableList component.