### PR TITLE
ヘッダー・フッターのレイアウト調整

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -153,6 +153,7 @@ const currentLocale = Astro.currentLocale || "ja";
     flex-direction: row;
     gap: 24px;
     width: 100%;
+    padding: 0 24px;
     flex-wrap: wrap;
   }
 
@@ -270,7 +271,7 @@ const currentLocale = Astro.currentLocale || "ja";
     background: var(--gradient);
   }
 
-  @media (max-width: 860px) {
+  @media (max-width: 1180px) {
     .site-link-group {
       display: none;
     }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -37,7 +37,7 @@ const currentLocale = Astro.currentLocale || "ja";
     & img {
       vertical-align: middle;
 
-      @media screen and (max-width: 860px) {
+      @media screen and (max-width: 1180px) {
         & {
           height: 50px;
           width: auto;
@@ -70,7 +70,7 @@ const currentLocale = Astro.currentLocale || "ja";
       }
     }
 
-    @media screen and (max-width: 860px) {
+    @media screen and (max-width: 1180px) {
       & {
         position: fixed;
         top: 66px;
@@ -114,7 +114,7 @@ const currentLocale = Astro.currentLocale || "ja";
     border-radius: 100%;
     cursor: pointer;
 
-    @media screen and (max-width: 860px) {
+    @media screen and (max-width: 1180px) {
       & {
         display: inline-flex;
       }
@@ -149,7 +149,7 @@ const currentLocale = Astro.currentLocale || "ja";
     padding: 0;
     list-style: none;
 
-    @media screen and (max-width: 860px) {
+    @media screen and (max-width: 1180px) {
       & {
         padding: 0 8px;
       }
@@ -196,7 +196,7 @@ const currentLocale = Astro.currentLocale || "ja";
       opacity: 0.7;
     }
 
-    @media screen and (max-width: 860px) {
+    @media screen and (max-width: 1180px) {
       & {
         padding-left: 16px;
         font-size: 24px;
@@ -209,7 +209,7 @@ const currentLocale = Astro.currentLocale || "ja";
     height: 20px;
     fill: currentColor;
 
-    @media screen and (max-width: 860px) {
+    @media screen and (max-width: 1180px) {
       & {
         width: 24px;
         height: 24px;


### PR DESCRIPTION
- ヘッダーは860pxでハンバーガーメニューに各リンクが押し込まれるようになっている
- フロアマップが追加されると860pxだと収まりきらず、ヘッダー内の文字が折り返されてしまうので、もう少し早めにハンバーガーメニューに切り替わるようにしました
- フッターも合わせて各リンクが消えるタイミングを調整 + 余白の調整