### PR TITLE
フッターのボックスのpaddingが飛び出していたのを修正

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -155,6 +155,7 @@ const currentLocale = Astro.currentLocale || "ja";
     width: 100%;
     padding: 0 24px;
     flex-wrap: wrap;
+    box-sizing: border-box;
   }
 
   .link-column {


### PR DESCRIPTION
## 概要
公式サイトのフッターのpaddingの影響で、スマホで見たときにスタイルが崩れていたので修正しました。

### 変更前

<img width="300" height="738" alt="image" src="https://github.com/user-attachments/assets/d228a72b-7cfb-494c-bd7d-ef2102fa310b" />

<img width="300" height="791" alt="image" src="https://github.com/user-attachments/assets/415a709c-0e81-4791-90e7-0b523e35d7b3" />

### 変更後

<img width="300" height="679" alt="image" src="https://github.com/user-attachments/assets/0fa9499f-f595-41fe-b423-0c5f4a4829f0" />