### PR TITLE
gocon.jp配下でヘルプページのリダイレクトできない

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,4 @@
 /help https://docs.google.com/document/d/e/2PACX-1vTND_zm397IJTp4cbZwR3tpOhnsTtLIkDwcqDfMTg1K0jjWrHJ7i70ukkwukW2nL0nioqdCbOUG8E6I/pub 301
 /en/help https://docs.google.com/document/d/e/2PACX-1vTND_zm397IJTp4cbZwR3tpOhnsTtLIkDwcqDfMTg1K0jjWrHJ7i70ukkwukW2nL0nioqdCbOUG8E6I/pub 301
+/2025/help https://docs.google.com/document/d/e/2PACX-1vTND_zm397IJTp4cbZwR3tpOhnsTtLIkDwcqDfMTg1K0jjWrHJ7i70ukkwukW2nL0nioqdCbOUG8E6I/pub 301
+/2025/en/help https://docs.google.com/document/d/e/2PACX-1vTND_zm397IJTp4cbZwR3tpOhnsTtLIkDwcqDfMTg1K0jjWrHJ7i70ukkwukW2nL0nioqdCbOUG8E6I/pub 301


### PR DESCRIPTION
- 公開後の `https://gocon.jp/2025/help` ではリダイレクトがうまく動かなかったので、2025をパスに含めた状態の設定も追加しました