### PR TITLE
💄 Safariでジョブボードの表示が崩れる問題を修正

### DIFF
--- a/src/components/JobBoardCard.astro
+++ b/src/components/JobBoardCard.astro
@@ -46,9 +46,10 @@ const { src, alt, width, height, link } = Astro.props;
       grid-template-columns: 1fr; /* 1200px以下なら1列 */
       width: unset;
       height: unset;
-      max-width: 1120px;
-      max-height: 560px;
       aspect-ratio: 2 / 1;
+      /* grid内のaspect-ratioを指定するとSafariではうまくサイズ計算できない不具合への対策 */
+      min-width: 0;
+      min-height: 0;
     }
   }
 </style>


### PR DESCRIPTION
## やったこと

`display: grid` 内で `aspect-ratio` を設定した時にSafariではサイズの計算がうまくできなくなるバグがあるので、それに対応するための修正を行いました